### PR TITLE
README to explain submodules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 build
+CMakeFiles
+CMakeCache.txt
+elf2uf2
+pioasm
+generated

--- a/README.md
+++ b/README.md
@@ -1,23 +1,40 @@
 # SataTo3DO
-The goal of this project is to replace the physical drive of my NTSC FZ-1 with a low cost ODE
-In PCB directory, the final PCB can be found and oredered in some companies like PCBWay or JLCPCB
+The goal of this project is to replace the physical drive of my NTSC FZ-1 with a low-cost ODE.
+
+## Hardware Construction
+In the `PCB` directory, the `SATA23DO_final.zip` gerbers for the PCB can be found and ordered from a fabricator such as PCBWay or JLCPCB.
 
 For the BOM:
-- 1 RP2040 moudle: RP2040-plus from waveshare: https://www.waveshare.com/wiki/RP2040-Plus
-- 6 level bi-directional shifter: https://fr.aliexpress.com/item/32890488553.html
-- 1 Octal bus tranceiver 74HC245N in DIP format
-- 1 2x6 connector 1.5mm (to be populated on POWER_1)
-- 1 2x15 connector 1.5mm (to be populated on CDROM)
+- 1x RP2040 module: RP2040-Plus from WaveShare: https://www.waveshare.com/wiki/RP2040-Plus
+- 6x bi-directional level shifter modules: https://fr.aliexpress.com/item/32890488553.html
+- 1x Octal bus tranceiver 74HC245N in DIP format
+- 1x 2x6 connector 1.5mm (to be populated on POWER_1)
+- 1x 2x15 connector 1.5mm (to be populated on CDROM)
 
-All other parts are not required. If you want to debug code, you can add a header on uart port and plug a UAR to USB adapter (I am using minicom on linux to see the traces)
+All other parts are not required to be populated. If you want to debug code, you can add a header on the UART port, and connect a UART to USB adapter (I am using minicom on Linux as a serial console to see the traces.)
 
-Regarding connectors, take care to order the right one depending your cable.
+Regarding connectors, take care to order the right one depending your 3DO's cable.
 
-Use the attached source to compile a uf2 image and copy it on the Rp2040 module.
-Plug a USB-C usb key (CDROM support is preliminary, it requires extra power), do not use a SSD (consuming lot of power).
-USB key shall be formatted as FAT32 or exFat.
+## Building Source Code
+Use the attached source to compile a uf2 image using cmake, and copy it onto the RP2040 module (connected via USB.)
+
+Note that `tinyusb` and `pico-sdk` come from git submodules. They can be cloned using the command:
+
+```bash
+git submodule update --init --recursive
+```
+
+Otherwise, cmake will raise errors that it cannot find the necessary include files.
+
+## Setup
+Plug a USB-C usb flash drive key (CDROM support is preliminary, it requires extra power), do not use a SSD (consuming lot of power).
+
+USB flash drive must be formatted as either the FAT32 or exFat file systems.
+
 At the root of the usb key, copy the [boot.iso](https://github.com/fixelsan/3do-ode-firmware/blob/master/boot.iso) you can find on fixel's homepage (it is compatible).
-Copy your game as you want on the USB disk.
-There is no ordering algorithm supported, so the order will follow the FAT entry order. This means the first game you will transfer to the USB stick will be the first one in the list.
+
+Copy your desired game ISOs to the USB disk.
+
+There is no sorting algorithm supported, so the order displayed on the 3DO will follow the FAT entry order. This means the first game you will transfer to the USB stick will be the first one in the list.
 
 Do not hesitate to contribute with MR.


### PR DESCRIPTION
Updated the README to contain sections and information about getting `tinyusb` and `pico-sdk` out of git submodules, as other people might not know about this step of the RP2040 build process.

Also ignored some temporary CMake files. Thanks for the great project!